### PR TITLE
Allowing for templates, fixed one bug, making validators longer

### DIFF
--- a/hellosign/hello_objects.py
+++ b/hellosign/hello_objects.py
@@ -3,8 +3,8 @@ from wtforms import Form, TextField, validators
 
 
 class HelloSigner(Form):
-    name = TextField('Name', [validators.Length(min=2, max=32)])
-    email = TextField('Email', [validators.Length(min=6, max=128), validators.Email()])
+    name = TextField('Name', [validators.Length(min=2, max=255)])
+    email = TextField('Email', [validators.Length(min=6, max=255), validators.Email()])
 
 
 class HelloDoc(Form):
@@ -24,4 +24,4 @@ class HelloDoc(Form):
 
 
 class HelloTeam(Form):
-    name = TextField('Name', [validators.Length(min=1, max=25)])
+    name = TextField('Name', [validators.Length(min=1, max=255)])

--- a/hellosign/hello_objects.py
+++ b/hellosign/hello_objects.py
@@ -4,7 +4,7 @@ from wtforms import Form, TextField, validators
 
 class HelloSigner(Form):
     name = TextField('Name', [validators.Length(min=2, max=255)])
-    email = TextField('Email', [validators.Length(min=6, max=255), validators.Email()])
+    email = TextField('Email', [validators.required(), validators.Length(min=6, max=255), validators.Email()])
 
 
 class HelloDoc(Form):

--- a/hellosign/hellosign.py
+++ b/hellosign/hellosign.py
@@ -47,8 +47,14 @@ class HelloSignSignature(HelloSign):
                 raise Exception("add_doc doc must be an instance of class HelloDoc")
 
     def validate(self):
+        self.validate_signers()
+        self.validate_docs()
+
+    def validate_signers(self):
         if len(self.signers) == 0:
             raise AttributeError('You need to specify at least 1 person as a signer')
+
+    def validate_docs(self):
         if len(self.docs) == 0:
             raise AttributeError('You need to specify at least 1 document')
 
@@ -90,8 +96,7 @@ class HelloSignSignature(HelloSign):
             auth = kwargs['auth']
             del(kwargs['auth'])
 
-        self.validate_signers()
-        self.validate_docs()
+        self.validate()
 
         return self.signature_request.send.post(auth=auth, data=self.data(), files=self.files(), **kwargs)
 

--- a/hellosign/hellosign.py
+++ b/hellosign/hellosign.py
@@ -32,7 +32,7 @@ class HelloSignSignature(HelloSign):
             self.signers.append(signer)
         else:
             if not signer.validate():
-                raise Exception("HelloSigner Errors %s" % (signers.errors,))
+                raise Exception("HelloSigner Errors %s" % (signer.errors,))
             else:
                 raise Exception("add_signer signer must be an instance of class HelloSigner")
 
@@ -90,9 +90,27 @@ class HelloSignSignature(HelloSign):
             auth = kwargs['auth']
             del(kwargs['auth'])
 
-        self.validate()
+        self.validate_signers()
+        self.validate_docs()
 
         return self.signature_request.send.post(auth=auth, data=self.data(), files=self.files(), **kwargs)
+
+    def create_from_template(self, template_id, custom_fields=None, *args, **kwargs):
+        auth=None
+        if 'auth' in kwargs:
+            auth = kwargs['auth']
+            del(kwargs['auth'])
+
+        self.validate_signers()
+
+        data = self.data()
+        data['reusable_form_id'] = template_id
+
+        if custom_fields:
+            for k, v in custom_fields.items():
+                data['custom_fields[%s]' % k] = v
+
+        return self.signature_request.send_with_reusable_form.post(auth=auth, data=data, **kwargs)
 
 
 class HelloSignEmbeddedDocumentSignature(HelloSignSignature):


### PR DESCRIPTION
3 changes:
1) fixed a bug referring to 'signers' rather than 'signer'
2) added a method for creating a document from a template
3) increased the name/email validator length to 255, as that is the valid length in the API and sometimes you need it. Also made email required, because well it is.
